### PR TITLE
Improve SEv.Map:BlockEntCleanup()

### DIFF
--- a/lua/sandev/libs/map/sh_map.lua
+++ b/lua/sandev/libs/map/sh_map.lua
@@ -30,6 +30,8 @@ function game.CleanUpMap(dontSendToClients, extraFilters, ...)
             local classname = ent:GetClass()
             local newClassName = 'sev_cleanup_protection_' .. tostring(ent)
 
+            -- The function checks the "classname" key value on entities. If it finds that value in the filter, then it skips the entity.
+            -- So, we change our protected entities' classname key value to something unique and add it to the filter.
             ent:SetKeyValue('classname', newClassName)
             
             extraFilters[#extraFilters + 1] = newClassName
@@ -41,6 +43,7 @@ function game.CleanUpMap(dontSendToClients, extraFilters, ...)
 
     SEv_gameCleanUpMap(dontSendToClients, extraFilters, ...)
 
+    -- Return the protected entities' classnames back to their original name
     for ent, classname in pairs(protectedEntities) do
         if ent:IsValid() then
             ent:SetKeyValue('classname', classname)


### PR DESCRIPTION
Instead of adding the classnames of our protected entities to the filter and removing the unprotected entities with the same classname, we use :SetKeyValue() on them and change their classname to something unique and add them to the filter. 